### PR TITLE
Simplify source type - use "gcp"

### DIFF
--- a/rules/google_cloud_exposed_service_account_key.yml
+++ b/rules/google_cloud_exposed_service_account_key.yml
@@ -13,7 +13,7 @@ description: |-
 enabled: true
 severity: Critical
 query_text: |-
-  %ingest.source_type:gcp.*
+  %ingest.source_type:gcp
   protoPayload.authenticationInfo.principalEmail:gcp-compromised-key-response@system.gserviceaccount.com
   protoPayload.methodName:google.iam.admin.v1.DisableServiceAccountKey
   | groupbycount(protoPayload.authenticationInfo.principalEmail)

--- a/rules/google_cloud_iam_policy_modified.yml
+++ b/rules/google_cloud_iam_policy_modified.yml
@@ -12,7 +12,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.project
+  %ingest.source_type:gcp
   protoPayload.methodName:SetIamPolicy
   | groupbycount(protoPayload.authenticationInfo.principalEmail)
   | where @q.count > 0

--- a/rules/google_cloud_iam_role_created.yml
+++ b/rules/google_cloud_iam_role_created.yml
@@ -15,7 +15,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.iam.role
+  %ingest.source_type:gcp
   protoPayload.methodName:google.iam.admin.v1.CreateRole
   | groupbycount(protoPayload.authenticationInfo.principalEmail)
   | where @q.count > 0

--- a/rules/google_cloud_logging_sink_modified.yml
+++ b/rules/google_cloud_logging_sink_modified.yml
@@ -15,7 +15,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.logging.sink
+  %ingest.source_type:gcp
   protoPayload.methodName:(google.logging.v2.ConfigServiceV2.UpdateSink google.logging.v2.ConfigServiceV2.DeleteSink)
   | groupbycount(protoPayload.authenticationInfo.principalEmail, data.protoPayload.resourceName)
   | where @q.count > 0

--- a/rules/google_cloud_project_external_principal_added_as_project_owner.yml
+++ b/rules/google_cloud_project_external_principal_added_as_project_owner.yml
@@ -19,7 +19,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:gcp.project
+  %ingest.source_type:gcp
   protoPayload.serviceName:cloudresourcemanager.googleapis.com
   protoPayload.methodName:InsertProjectOwnershipInvite
   data.protoPayload.request.member:(*gmail.com *googlemail.com)

--- a/rules/google_cloud_pub_sub_subscriber_modified.yml
+++ b/rules/google_cloud_pub_sub_subscriber_modified.yml
@@ -15,7 +15,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.pubsub.subscription
+  %ingest.source_type:gcp
   protoPayload.methodName:(google.pubsub.v1.Subscriber.UpdateSubscription google.pubsub.v1.Subscriber.DeleteSubscription)
   | groupbycount(protoPayload.authenticationInfo.principalEmail, data.protoPayload.resourceName)
   | where @q.count > 0

--- a/rules/google_cloud_pub_sub_topic_deleted.yml
+++ b/rules/google_cloud_pub_sub_topic_deleted.yml
@@ -12,7 +12,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.pubsub.topic
+  %ingest.source_type:gcp
   protoPayload.methodName:google.pubsub.v1.Publisher.DeleteTopic
   | groupbycount(protoPayload.authenticationInfo.principalEmail, data.protoPayload.resourceName)
   | where @q.count > 0

--- a/rules/google_cloud_service_account_created.yml
+++ b/rules/google_cloud_service_account_created.yml
@@ -12,7 +12,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.service.account
+  %ingest.source_type:gcp
   protoPayload.methodName:google.iam.admin.v1.CreateServiceAccount
   | groupbycount(protoPayload.authenticationInfo.principalEmail)
   | where @q.count > 0

--- a/rules/google_cloud_service_account_key_created.yml
+++ b/rules/google_cloud_service_account_key_created.yml
@@ -12,7 +12,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.service.account
+  %ingest.source_type:gcp
   protoPayload.methodName:google.iam.admin.v1.CreateServiceAccountKey
   | groupbycount(protoPayload.authenticationInfo.principalEmail)
   | where @q.count > 0

--- a/rules/google_cloud_sql_database_modified.yml
+++ b/rules/google_cloud_sql_database_modified.yml
@@ -16,7 +16,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.cloudsql.database
+  %ingest.source_type:gcp
   protoPayload.methodName:(cloudsql.instances.create cloudsql.instances.create cloudsql.users.create cloudsql.users.update)
   | groupbycount(project_id, database_id, protoPayload.authenticationInfo.principalEmail)
   | where @q.count > 0

--- a/rules/google_cloud_storage_bucket_contents_downloaded_without_authentication.yml
+++ b/rules/google_cloud_storage_bucket_contents_downloaded_without_authentication.yml
@@ -12,7 +12,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.gcs.bucket
+  %ingest.source_type:gcp
   (not protoPayload.authenticationInfo.principalEmail:*)
   protoPayload.methodName:storage.objects.get
   severity:info

--- a/rules/google_cloud_storage_bucket_enumerated.yml
+++ b/rules/google_cloud_storage_bucket_enumerated.yml
@@ -15,7 +15,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.gcs.bucket
+  %ingest.source_type:gcp
   protoPayload.methodName:storage.buckets.list
   protoPayload.authenticationInfo.principalEmail:*gserviceaccount.com
   | groupbycount(project_id, protoPayload.authenticationInfo.principalEmail)

--- a/rules/google_cloud_storage_bucket_modified.yml
+++ b/rules/google_cloud_storage_bucket_modified.yml
@@ -14,7 +14,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.gcs.bucket
+  %ingest.source_type:gcp
   protoPayload.methodName:storage.buckets.update
   | groupbycount(project_id, bucket_name, protoPayload.authenticationInfo.principalEmail)
   | where @q.count > 0

--- a/rules/google_cloud_storage_bucket_permissions_modified.yml
+++ b/rules/google_cloud_storage_bucket_permissions_modified.yml
@@ -13,7 +13,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.gcs.bucket
+  %ingest.source_type:gcp
   protoPayload.methodName:storage.setIamPermissions
   (not protoPayload.status.message:ERROR)
   | groupbycount(project_id, bucket_name, protoPayload.authenticationInfo.principalEmail)

--- a/rules/google_compute_engine_firewall_rule_modified.yml
+++ b/rules/google_compute_engine_firewall_rule_modified.yml
@@ -17,7 +17,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.gce.firewall.rule
+  %ingest.source_type:gcp
   protoPayload.methodName:(v1.compute.firewalls.delete v1.compute.firewalls.insert v1.compute.firewalls.patch)
   | groupbycount(project_id, data.protoPayload.resourceOriginalState.name, protoPayload.authenticationInfo.principalEmail)
   | where @q.count > 0

--- a/rules/google_compute_engine_network_route_created_or_modified.yml
+++ b/rules/google_compute_engine_network_route_created_or_modified.yml
@@ -15,7 +15,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:gcp.gce.route
+  %ingest.source_type:gcp
   protoPayload.methodName:(beta.compute.routes.insert beta.compute.routes.patch)
   | groupbycount(project_id, data.protoPayload.resourceName, protoPayload.authenticationInfo.principalEmail)
   | where @q.count > 0


### PR DESCRIPTION
From user feedback. Simplify GCP audit log source type. Use `"gcp"` everywhere.