### PR TITLE
Remove `enabled` field from rules

### DIFF
--- a/rules/google_cloud_exposed_service_account_key.yml
+++ b/rules/google_cloud_exposed_service_account_key.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. An abuse event is logged.
   2. Investigate any other actions performed by the compromised identity using the investigation tool.
-enabled: true
 severity: Critical
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_cloud_iam_policy_modified.yml
+++ b/rules/google_cloud_iam_policy_modified.yml
@@ -9,7 +9,6 @@ description: |-
 
   ## Triage and response
   Review the log and inspect the policy deltas to ensure none of the actions are "REMOVE."
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_cloud_iam_role_created.yml
+++ b/rules/google_cloud_iam_role_created.yml
@@ -12,7 +12,6 @@ description: |-
   ## Triage and response
   1. Investigate the user who created the IAM role and ensure the permissions in the response are scoped properly.
   2. Review the users associated with the role to ensure they should have the attached permissions.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_cloud_logging_bucket_deleted.yml
+++ b/rules/google_cloud_logging_bucket_deleted.yml
@@ -10,7 +10,6 @@ description: |-
 
   ## Triage and response
   Assess if the Google Cloud user should be deleting the logging bucket indicated by the resource name.
-enabled: true
 severity: Medium
 query_text: |-
   protoPayload.serviceName:logging.googleapis.com

--- a/rules/google_cloud_logging_sink_modified.yml
+++ b/rules/google_cloud_logging_sink_modified.yml
@@ -12,7 +12,6 @@ description: |-
 
   ## Triage and response
   Review the sink to ensure it is properly configured.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_cloud_project_external_principal_added_as_project_owner.yml
+++ b/rules/google_cloud_project_external_principal_added_as_project_owner.yml
@@ -16,7 +16,6 @@ description: |-
   2. If the action is legitimate, consider adding the user or service account to a suppression list.
   3. Otherwise, review the User Investigation dashboard to see if the user or service account has taken other actions.
   4. If the triage indicates the action was taken by an attacker, initiate your company's incident response process and investigate.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_cloud_pub_sub_subscriber_modified.yml
+++ b/rules/google_cloud_pub_sub_subscriber_modified.yml
@@ -12,7 +12,6 @@ description: |-
 
   ## Triage and response
   Review the subscription to ensure it is properly configured.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_cloud_pub_sub_topic_deleted.yml
+++ b/rules/google_cloud_pub_sub_topic_deleted.yml
@@ -9,7 +9,6 @@ description: |-
 
   ## Triage and Response
   Review the subscription to ensure it is properly configured.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_cloud_service_account_created.yml
+++ b/rules/google_cloud_service_account_created.yml
@@ -9,7 +9,6 @@ description: |-
 
   ## Triage and response
   Contact the user who created the service account to confirm its necessity and proper role scoping.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_cloud_service_account_key_created.yml
+++ b/rules/google_cloud_service_account_key_created.yml
@@ -9,7 +9,6 @@ description: |-
 
   ## Triage and response
   Contact the user who created the service account key to ensure they are managing it securely.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_cloud_sql_database_modified.yml
+++ b/rules/google_cloud_sql_database_modified.yml
@@ -13,7 +13,6 @@ description: |-
 
   ## Triage and response
   1. Review the Google Cloud SQL database to ensure it is properly configured with the correct permissions.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_cloud_storage_bucket_contents_downloaded_without_authentication.yml
+++ b/rules/google_cloud_storage_bucket_contents_downloaded_without_authentication.yml
@@ -9,7 +9,6 @@ description: |-
 
   ## Triage and response
   Investigate the logs to determine if the accessed bucket should be accessible to unauthenticated users.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_cloud_storage_bucket_enumerated.yml
+++ b/rules/google_cloud_storage_bucket_enumerated.yml
@@ -12,7 +12,6 @@ description: |-
   Determine whether the service account should be making list bucket calls.
   * If the account was compromised, secure it and investigate the compromise and any unauthorized activity.
   * If the service account owner intended to make the list buckets call, evaluate the necessity of the call, as it could pose a security risk. If it's unnecessary, adjust the rule's filter to stop generating signals for this account.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_cloud_storage_bucket_modified.yml
+++ b/rules/google_cloud_storage_bucket_modified.yml
@@ -11,7 +11,6 @@ description: |-
 
   ## Triage and response
   Review the bucket to ensure proper configuration.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_cloud_storage_bucket_permissions_modified.yml
+++ b/rules/google_cloud_storage_bucket_permissions_modified.yml
@@ -10,7 +10,6 @@ description: |-
 
   ## Triage and response
   Review the bucket permissions to ensure they are not overly permissive.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_compute_engine_firewall_rule_modified.yml
+++ b/rules/google_compute_engine_firewall_rule_modified.yml
@@ -14,7 +14,6 @@ description: |-
   ## Triage and response
   1. Review the log and role to ensure proper permissions.
   2. Check the users associated with the role to confirm they should have those permissions.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp

--- a/rules/google_compute_engine_network_route_created_or_modified.yml
+++ b/rules/google_compute_engine_network_route_created_or_modified.yml
@@ -12,7 +12,6 @@ description: |-
 
   ## Triage and response
   Ensure the GCE network route is configured correctly and confirm the user's intention to modify the firewall.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:gcp


### PR DESCRIPTION
Support staging state for out-of-the-box rules. The enabled flag should not take precedence when users add rules with staging state.